### PR TITLE
Added Intellij plugin support for connecting to lab devices in intellij IDE

### DIFF
--- a/driver/src/org/xframium/driver/TXTConfigurationReader.java
+++ b/driver/src/org/xframium/driver/TXTConfigurationReader.java
@@ -394,7 +394,7 @@ public class TXTConfigurationReader extends AbstractConfigurationReader
         switch ( (configProperties.getProperty( DEVICE[0] )).toUpperCase() )
         {
             case "PERFECTO_PLUGIN":
-                DataManager.instance().readData( new PerfectoMobilePluginProvider( configProperties.get( "deviceManagement.deviceList" ) + "", DriverType.valueOf( configProperties.getProperty( DEVICE[1] ) ) ) );
+                DataManager.instance().readData( new PerfectoMobilePluginProvider( configProperties.get( "deviceManagement.deviceList" ) + "", DriverType.valueOf( configProperties.getProperty( DEVICE[1] ) ), configProperties.getProperty( "deviceManagement.pluginType" ) ) );
                 break;
             
             case "RESERVED":

--- a/driver/src/org/xframium/driver/XMLConfigurationReader.java
+++ b/driver/src/org/xframium/driver/XMLConfigurationReader.java
@@ -476,7 +476,7 @@ public class XMLConfigurationReader extends AbstractConfigurationReader implemen
         switch ( xRoot.getDevices().getProvider() )
         {
             case "PERFECTO_PLUGIN":
-                DataManager.instance().readData( new PerfectoMobilePluginProvider( configProperties.get( "deviceManagement.deviceList" ) + "", DriverType.valueOf( xRoot.getDriver().getType() ) ) );
+                DataManager.instance().readData( new PerfectoMobilePluginProvider( configProperties.get( "deviceManagement.deviceList" ) + "", DriverType.valueOf( xRoot.getDriver().getType() ), configProperties.get( "deviceManagement.pluginType" ) ) );
                 break;
             
             case "RESERVED":

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -82,6 +82,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <failOnError>false</failOnError>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -90,6 +93,13 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+	        <groupId>org.apache.httpcomponents</groupId>
+	        <artifactId>httpclient</artifactId>
+	        <version>4.5.2</version>
+	      </dependency>
+	    </dependencies>
       </plugin>
     </plugins>
   </build>
@@ -163,6 +173,11 @@
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <version>2.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.perfectomobile</groupId>
+      <artifactId>intellij-connector</artifactId>
+      <version>9.0.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.perfecto.reporting-sdk</groupId>

--- a/framework/src/org/xframium/device/data/DataProvider.java
+++ b/framework/src/org/xframium/device/data/DataProvider.java
@@ -45,6 +45,18 @@ public interface DataProvider
 		APPIUM;
 	}
 	/**
+	 * The Enum PluginType.
+	 */
+	public enum PluginType
+	{
+
+		/** Eclipse Lab Plugin */
+		ECLIPSE,
+
+		/** Intellij Lab Plugin */
+		INTELLIJ;
+	}
+	/**
 	 * Read data.
 	 */
 	public void readData();


### PR DESCRIPTION
Added a new config parameter deviceManagement.pluginType.  If this is set to =INTELLIJ and deviceManagement.provider=PERFECTO_PLUGIN then it will attempt to connect to the Intellij plugin socket to get the execution id.

I passed the pluginType parameter as a String even though I added a pluginType enum because I wanted it to remain backwards compatible when deviceManagement.provider wasn't specified and it would default to using the Eclipse connector.

I added the intellij lib dependency to the pom and I also had to add a dependency to the maven-javadoc-plugin otherwise that plugin would cause the build to fail.
